### PR TITLE
Update portfolio header design, move layout towards a 16 column grid

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,8 +2,13 @@
 <html lang="en-GB">
     <head>
         <meta charset="utf-8"/>
-
-        <title>{{ page.title }}</title>
+        {% if page.layout == 'portfolio' %}
+            <title>{{ page.title }} - {{ page.topic }} - Andrew Mee</title>
+        {% elsif page.layout == 'post' %}
+            <title>{{ page.title }} - Andrew Mee</title>
+        {% else %}
+            <title>{{ page.title }}</title>
+        {% endif %}
         <meta name="description" content="{{ page.description }}" />
 
         <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/_layouts/portfolio.html
+++ b/_layouts/portfolio.html
@@ -8,42 +8,53 @@ layout: default
     </a>
 </header>
 
-<article class="container">
-    <img class="portfolio-hero" src="{{ page.hero }}">
+<article>
     <header class="portfolio-header">
-        {{page.topic}}
-        <h1>{{ page.title }}</h1>
+        <img class="portfolio-header__hero" src="{{ page.hero }}">
+        
+        <div class="container">
+            <div class="portfolio-header__content">
+                {{page.topic}}
+                <h1>{{ page.title }}</h1>
 
-        <dl class="portfolio-header__info">
-            <dt>Client{% if page.clients.size > 0 %}s{% endif %}</dt>
-            {% for client in page.clients %}
-                <dd>
-                    {% if client.url %}
-                        <a href="{{ client.url }}">
-                            {{ client.name }}
-                        </a>
-                    {% else %}
+                <dl class="portfolio-header__info">
+                    <dt>Client{% if page.clients.size > 0 %}s{% endif %}</dt>
+                    {% for client in page.clients %}
+                    <dd>
+                        {% if client.url %}
+                        <a href="{{ client.url }}">{{ client.name }}</a>
+                        {% else %}
                         {{ client.name }}
-                    {% endif %}
-                </dd>
-            {% endfor %}
-
-            <dt>Type</dt>
-            {% for type in page.type %}
-                <dd>{{ type }}</dd>
-            {% endfor %}
-
-            <dt>Sector</dt>
-            {% for sector in page.sector %}
-                <dd>{{ sector }}</dd>
-            {% endfor %}
-
-            <dt>Date</dt>
-            <dd><time datetime="{{ page.date | date: '%Y-%m-%dT%H:%M:%SZ' }}">{{ page.date | date: '%d %B %Y' }}</time></dd>
-        </dl>
+                        {% endif %}
+                    </dd>
+                    {% endfor %}
+                </dl>
+                    
+                <dl class="portfolio-header__info">
+                    <dt>Type</dt>
+                    {% for type in page.type %}
+                    <dd>{{ type }}</dd>
+                    {% endfor %}
+                </dl>
+                    
+                <dl class="portfolio-header__info">
+                    <dt>Sector</dt>
+                    {% for sector in page.sector %}
+                    <dd>{{ sector }}</dd>
+                    {% endfor %}
+                </dl>
+                    
+                <dl class="portfolio-header__info">
+                    <dt>Date</dt>
+                    <dd><time datetime="{{ page.date | date: '%Y-%m-%dT%H:%M:%SZ' }}">{{ page.date | date: '%d %B %Y' }}</time></dd>
+                </dl>
+            </div>
+        </div>
     </header>
 
-    {{ content }}
+    <div class="container">
+        {{ content }}
+    </div>
 </article>
 
 {% include footer.html %}

--- a/_layouts/portfolio.html
+++ b/_layouts/portfolio.html
@@ -2,14 +2,10 @@
 layout: default
 ---
 
-<header class="container site-header">
-    <div class="gutters">
-        <div class="pull-left">
-            <a href="/">
-                {% include logo.html classes="" %}
-            </a>
-        </div>
-    </div>
+<header class="container site-header site-header--overlay">
+    <a href="/">
+        {% include logo.html classes="" %}
+    </a>
 </header>
 
 <article class="container">

--- a/resources/styles/base/layout.scss
+++ b/resources/styles/base/layout.scss
@@ -1,3 +1,11 @@
+html {
+  box-sizing: border-box;
+}
+
+*, *:before, *:after {
+  box-sizing: inherit;
+}
+
 .container {
   margin: 0 auto;
   max-width: 1200px;
@@ -14,34 +22,9 @@ img {
 
 @media screen and (min-width: $breakpoint-small) {
 
-  .gutters {
-    margin-left: 20%;
-  }
-
-  .bleed-left,
-  .pull-left {
-    float: left;
-    margin-left: -25%;
-    padding-right: $gutter;
-  }
-  
-  .bleed-left {
-    margin-bottom: $gutter;
-    max-width: 80%;
-  }
-  
-  img.bleed-left {
-    max-width: 125%;
-  }
-
-  .pull-left {
-    box-sizing: border-box;
-    text-align: right;
-    width: 25%;
-  }
-
-  .gutter-left {
-    margin-left: 20%;
+  .gutters,
+  .gutter-right {
+    margin-right: $columns-3;
   }
 
 }
@@ -49,29 +32,21 @@ img {
 @media screen and (min-width: $breakpoint-medium) {
 
   .gutters {
-    margin-right: 20%;
-
-    .bleed-right {
-      margin-right: -33.33%;
-    }
-
-    .bleed-left,
-    .pull-left {
-      margin-left: -33.333%;
-    }
-
-    .bleed-left,
-    .bleed-right {
-      max-width: 133.33%;
-    }
+    margin-left: $columns-3;
 
     .pull-left {
-      width: 33.333%;
+      float: left;
+      // margin-left: -$columns-3;
+      margin-left: -30%;
+      padding-right: $gutter;
+      text-align: right;
+      // width: $columns-3;
+      width: 30%;
     }
   }
 
-  .gutter-right {
-    margin-right: 20%;
+  .gutter-left {
+    margin-left: $columns-3;
   }
 
   .column {

--- a/resources/styles/base/typography.scss
+++ b/resources/styles/base/typography.scss
@@ -84,12 +84,12 @@ figcaption {
 }
 
 a {
-  color: #ff00a1;
+  color: $link-highlight;
   text-decoration-skip: ink;
 
   &:hover,
   &:focus {
-    background: #ff00a1;
+    background: $link-highlight;
     color: #fff;
     text-decoration: none;
   }

--- a/resources/styles/components/code-highlighting.scss
+++ b/resources/styles/components/code-highlighting.scss
@@ -7,7 +7,6 @@
   padding: 0 0 0 140px;
   position: relative;
 
-
   ::selection {
     background: #fff;
   }
@@ -20,7 +19,7 @@
 }
 
 .highlight code::before {
-  background: #ff00a1;
+  background: $link-highlight;
   color: #fff;
   content: attr(data-lang);
   display: block;

--- a/resources/styles/components/logo.scss
+++ b/resources/styles/components/logo.scss
@@ -3,11 +3,11 @@
   color: #000;
   display: flex;
   flex-wrap: wrap;
-  height: 100px;
+  height: 128px;
   padding: 14px;
   text-align: center;
   text-transform: uppercase;
-  width: 100px;
+  width: 128px;
   word-break: break-all;
   z-index: 1;
   
@@ -17,7 +17,7 @@
   }
   
   &:hover {
-    animation: font-twitch 5s 0s;
+    animation: font-twitch 2s 0s;
   }
 }
 
@@ -31,16 +31,12 @@ header {
     border: 0;
     color: #fff;
     font-size: 0.8rem;
-    height: 50px;
+    height: 66px;
     padding: 8px;
-    width: 50px;
+    width: 66px;
 
     span {
       line-height: 16.667px;
-    }
-
-    @media screen and (min-width: $breakpoint-small) {
-      margin-left: auto;
     }
 
     @media screen and (min-width: $breakpoint-medium) {
@@ -48,9 +44,10 @@ header {
       border: 2px solid;
       color: #000;
       font-size: 1.3rem;
-      height: 78px;
+      height: 98px;
+      margin-left: auto;
       padding: 10px;
-      width: 78px;
+      width: 98px;
 
       span {
         line-height: 26px;

--- a/resources/styles/components/portfolio-header.scss
+++ b/resources/styles/components/portfolio-header.scss
@@ -1,46 +1,71 @@
 .portfolio-header {
-  background: #fff;
-  box-sizing: border-box;
-  margin-bottom: 4em;
-  margin-top: 35vw;
+  
+  h1 {
+    border-bottom: 2px solid;
+    margin-bottom: 0;
+  }
+
+  &__hero {
+    display: block;
+    object-fit: cover;
+    max-height: 100vh;
+    width: 100%;
+  }
 
   @media screen and (min-width: $breakpoint-small) {
-    margin-left: calc(20% - #{$gutter});
-    margin-top: 15vw;
-    padding: $gutter;
   }
 
   @media screen and (min-width: $breakpoint-medium) {
-    margin-left: calc(20% - 40px);
-    padding: 40px;
-    width: 50%;
-  }
-}
+    color: #fff;
 
-.portfolio-header__info {
-  dt {
-    font-size: 1.5rem;
-    font-weight: bold;
+    .container {
+      padding: 0;
+      position: relative;
+    }
+
+    &__content {
+      bottom: 0;
+      left: $gutter;
+      position: absolute;
+      right: $gutter;
+    }
+
+    &__info {
+      float: left;
+      min-width: $columns-3;
+      max-width: $columns-4;
+      padding-right: $gutter;
+
+      a {
+        background-color: #fff;
+        color: #000;
+        mix-blend-mode: lighten;
+        padding: 0 0.2em;
+
+        &:hover {
+          color: $link-highlight;
+          mix-blend-mode: normal;
+        }
+      }
+    }
+  }
+
+  &__info {
     line-height: 1;
-    margin-top: 1em;
-  }
 
-  dd {
-    display: inline;
-    margin-left: 0;
-
-    & + dd:before {
-      content: "/ ";
+    dt {
+      margin-bottom: 0.4em;
+    }
+  
+    dd {
+      font-weight: 200;
+      display: inline;
+      margin-left: 0;
+  
+      & + dd:before {
+        content: "/ ";
+      }
     }
   }
 }
 
-.portfolio-hero {
-  background: #D6D0D0;
-  left: 0;
-  min-height: 50vw;
-  position: absolute;
-  top: 0;
-  width: 100%;
-  z-index: -1;
-}

--- a/resources/styles/components/posts.scss
+++ b/resources/styles/components/posts.scss
@@ -1,5 +1,14 @@
 .site-header {
   overflow: hidden;
+
+  &--overlay {
+    padding: 0;
+
+    .logo {
+      margin: $gutter;
+      position: absolute;
+    }
+  }
 }
 
 .post__date {

--- a/resources/styles/components/posts.scss
+++ b/resources/styles/components/posts.scss
@@ -44,6 +44,12 @@
   }
 }
 
+.theme--portfolio {
+  .site-header .logo {
+    color: #fff;
+  }
+}
+
 .theme--shock {
   .post__topic {
     background: orange;

--- a/resources/styles/main.scss
+++ b/resources/styles/main.scss
@@ -5,7 +5,14 @@ $breakpoint-large: "75em";
 $breakpoint-medium: "50em";
 $breakpoint-small: "40em";
 
-$gutter: 20px;
+$gutter: 24px;
+
+$columns-1: 100% / 16;
+$columns-2: $columns-1 * 2;
+$columns-3: $columns-1 * 3;
+$columns-4: $columns-1 * 4;
+
+$link-highlight: #ff00a1;
 
 @import "vendor/normalize";
 

--- a/resources/styles/pages/home.scss
+++ b/resources/styles/pages/home.scss
@@ -74,7 +74,7 @@ body {
 
       &:hover {
         background-color: white;
-        color: #ff00a1;
+        color: $link-highlight;
       }
     }
 


### PR DESCRIPTION
Opening up the design of the portfolio template to use more of the available width and give the hero image more unobscured focus.

From
![screen shot 2019-02-11 at 14 41 43](https://user-images.githubusercontent.com/24985/52570454-59f11300-2e0b-11e9-828a-d06c556b33bd.png)

To
![screen shot 2019-02-11 at 14 41 59](https://user-images.githubusercontent.com/24985/52570468-5f4e5d80-2e0b-11e9-895b-7aa433259077.png)
